### PR TITLE
feat: add forgot password and reset password with Resend email

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,6 +7,8 @@ import DashboardPage from './pages/DashboardPage.jsx'
 import GoalsPage from './pages/GoalsPage.jsx'
 import SavedMealsPage from './pages/SavedMealsPage.jsx'
 import CreateSavedMealPage from './pages/CreateSavedMealPage.jsx'
+import ForgotPasswordPage from './pages/ForgotPasswordPage.jsx'
+import ResetPasswordPage from './pages/ResetPasswordPage.jsx'
 
 function ProtectedRoute({ children }) {
   const { user, loading } = useAuth()
@@ -31,6 +33,8 @@ export default function App() {
     <Routes>
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
+      <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+      <Route path="/reset-password" element={<ResetPasswordPage />} />
       <Route path="/dashboard" element={
         <ProtectedRoute>
           <ProtectedLayout>

--- a/client/src/pages/ForgotPasswordPage.jsx
+++ b/client/src/pages/ForgotPasswordPage.jsx
@@ -1,0 +1,158 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useTheme } from '../context/ThemeContext.jsx'
+import axiosClient from '../api/axiosClient.js'
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const { theme, toggleTheme } = useTheme()
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setLoading(true)
+    try {
+      await axiosClient.post('/api/auth/forgot-password', { email })
+      setSubmitted(true)
+    } catch (err) {
+      // Always show success to prevent email enumeration
+      setSubmitted(true)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div style={{
+      maxWidth: '400px',
+      margin: '80px auto',
+      padding: '2rem',
+      background: 'var(--bg-primary)',
+      borderRadius: 'var(--radius-lg)',
+      border: '1px solid var(--border)'
+    }}>
+      {/* Theme toggle */}
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '1rem' }}>
+        <button
+          onClick={toggleTheme}
+          style={{
+            background: 'none',
+            border: '1px solid var(--border)',
+            borderRadius: 'var(--radius-sm)',
+            padding: '4px 10px',
+            cursor: 'pointer',
+            color: 'var(--text-secondary)',
+            fontSize: '13px'
+          }}
+        >
+          {theme === 'light' ? '🌙 Dark' : '☀️ Light'}
+        </button>
+      </div>
+
+      <h1 style={{ fontSize: '22px', marginBottom: '4px', color: 'var(--text-primary)' }}>
+        🥗 Chomp Tracker
+      </h1>
+
+      {submitted ? (
+        <div>
+          <div style={{
+            padding: '16px',
+            background: 'rgba(29,158,117,0.1)',
+            border: '1px solid var(--success)',
+            borderRadius: 'var(--radius-md)',
+            marginTop: '1rem',
+            marginBottom: '1rem'
+          }}>
+            <p style={{ color: 'var(--success)', fontSize: '14px', fontWeight: '500', marginBottom: '6px' }}>
+              ✓ Check your email
+            </p>
+            <p style={{ color: 'var(--text-secondary)', fontSize: '13px' }}>
+              If that email exists you will receive a reset link shortly. 
+              Check your spam folder if you don't see it.
+            </p>
+          </div>
+          <Link
+            to="/login"
+            style={{
+              display: 'block',
+              textAlign: 'center',
+              fontSize: '13px',
+              color: 'var(--text-primary)',
+              fontWeight: '500'
+            }}
+          >
+            ← Back to login
+          </Link>
+        </div>
+      ) : (
+        <>
+          <p style={{ color: 'var(--text-muted)', fontSize: '14px', marginBottom: '1.5rem' }}>
+            Enter your email and we'll send you a reset link
+          </p>
+
+          <form onSubmit={handleSubmit}>
+            <div style={{ marginBottom: '1.5rem' }}>
+              <label style={{
+                display: 'block',
+                fontSize: '13px',
+                color: 'var(--text-secondary)',
+                marginBottom: '6px'
+              }}>
+                Email
+              </label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                placeholder="your@email.com"
+                style={{
+                  width: '100%',
+                  padding: '10px',
+                  border: '1px solid var(--border)',
+                  borderRadius: 'var(--radius-sm)',
+                  background: 'var(--bg-input)',
+                  color: 'var(--text-primary)',
+                  fontSize: '14px',
+                  boxSizing: 'border-box'
+                }}
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading}
+              style={{
+                width: '100%',
+                padding: '11px',
+                background: 'var(--accent)',
+                color: 'var(--accent-text)',
+                border: 'none',
+                borderRadius: 'var(--radius-sm)',
+                fontSize: '14px',
+                fontWeight: '500',
+                cursor: loading ? 'not-allowed' : 'pointer',
+                opacity: loading ? 0.7 : 1,
+                marginBottom: '1rem'
+              }}
+            >
+              {loading ? 'Sending...' : 'Send Reset Link'}
+            </button>
+          </form>
+
+          <p style={{
+            textAlign: 'center',
+            fontSize: '13px',
+            color: 'var(--text-muted)'
+          }}>
+            Remember your password?{' '}
+            <Link to="/login" style={{ color: 'var(--text-primary)', fontWeight: '500' }}>
+              Login
+            </Link>
+          </p>
+        </>
+      )}
+    </div>
+  )
+}

--- a/client/src/pages/LoginPage.jsx
+++ b/client/src/pages/LoginPage.jsx
@@ -150,6 +150,23 @@ export default function LoginPage() {
           </div>
         </div>
 
+        <div style={{
+          textAlign: 'right',
+          marginTop: '4px',
+          marginBottom: '1rem'
+        }}>
+          <Link
+            to="/forgot-password"
+            style={{
+              fontSize: '12px',
+              color: 'var(--text-muted)',
+              textDecoration: 'none'
+            }}
+          >
+            Forgot password?
+          </Link>
+        </div>
+
         <button
           type="submit"
           disabled={loading}

--- a/client/src/pages/ResetPasswordPage.jsx
+++ b/client/src/pages/ResetPasswordPage.jsx
@@ -1,0 +1,230 @@
+import { useState } from 'react'
+import { useNavigate, useSearchParams, Link } from 'react-router-dom'
+import { useTheme } from '../context/ThemeContext.jsx'
+import axiosClient from '../api/axiosClient.js'
+
+export default function ResetPasswordPage() {
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [success, setSuccess] = useState(false)
+
+  const { theme, toggleTheme } = useTheme()
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const token = searchParams.get('token')
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError(null)
+
+    if (password !== confirmPassword) {
+      return setError('Passwords do not match')
+    }
+
+    if (password.length < 6) {
+      return setError('Password must be at least 6 characters')
+    }
+
+    setLoading(true)
+    try {
+      await axiosClient.post('/api/auth/reset-password', { token, password })
+      setSuccess(true)
+      setTimeout(() => navigate('/login'), 3000)
+    } catch (err) {
+      setError(err.response?.data?.error || 'Reset failed. Link may have expired.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!token) {
+    return (
+      <div style={{
+        maxWidth: '400px',
+        margin: '80px auto',
+        padding: '2rem',
+        background: 'var(--bg-primary)',
+        borderRadius: 'var(--radius-lg)',
+        border: '1px solid var(--border)',
+        textAlign: 'center'
+      }}>
+        <p style={{ color: 'var(--error)', marginBottom: '1rem' }}>
+          Invalid reset link
+        </p>
+        <Link to="/forgot-password" style={{ color: 'var(--text-primary)', fontWeight: '500' }}>
+          Request a new one
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div style={{
+      maxWidth: '400px',
+      margin: '80px auto',
+      padding: '2rem',
+      background: 'var(--bg-primary)',
+      borderRadius: 'var(--radius-lg)',
+      border: '1px solid var(--border)'
+    }}>
+      {/* Theme toggle */}
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '1rem' }}>
+        <button
+          onClick={toggleTheme}
+          style={{
+            background: 'none',
+            border: '1px solid var(--border)',
+            borderRadius: 'var(--radius-sm)',
+            padding: '4px 10px',
+            cursor: 'pointer',
+            color: 'var(--text-secondary)',
+            fontSize: '13px'
+          }}
+        >
+          {theme === 'light' ? '🌙 Dark' : '☀️ Light'}
+        </button>
+      </div>
+
+      <h1 style={{ fontSize: '22px', marginBottom: '4px', color: 'var(--text-primary)' }}>
+        🥗 Chomp Tracker
+      </h1>
+
+      {success ? (
+        <div>
+          <div style={{
+            padding: '16px',
+            background: 'rgba(29,158,117,0.1)',
+            border: '1px solid var(--success)',
+            borderRadius: 'var(--radius-md)',
+            marginTop: '1rem'
+          }}>
+            <p style={{ color: 'var(--success)', fontSize: '14px', fontWeight: '500', marginBottom: '6px' }}>
+              ✓ Password reset successfully!
+            </p>
+            <p style={{ color: 'var(--text-secondary)', fontSize: '13px' }}>
+              Redirecting you to login in 3 seconds...
+            </p>
+          </div>
+        </div>
+      ) : (
+        <>
+          <p style={{ color: 'var(--text-muted)', fontSize: '14px', marginBottom: '1.5rem' }}>
+            Enter your new password
+          </p>
+
+          {error && (
+            <p style={{
+              color: 'var(--error)',
+              fontSize: '13px',
+              marginBottom: '1rem',
+              padding: '8px',
+              background: 'rgba(226,75,74,0.1)',
+              borderRadius: 'var(--radius-sm)'
+            }}>
+              {error}
+            </p>
+          )}
+
+          <form onSubmit={handleSubmit}>
+            <div style={{ marginBottom: '1rem' }}>
+              <label style={{
+                display: 'block',
+                fontSize: '13px',
+                color: 'var(--text-secondary)',
+                marginBottom: '6px'
+              }}>
+                New Password
+              </label>
+              <div style={{ position: 'relative' }}>
+                <input
+                  type={showPassword ? 'text' : 'password'}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                  placeholder="At least 6 characters"
+                  style={{
+                    width: '100%',
+                    padding: '10px 40px 10px 10px',
+                    border: '1px solid var(--border)',
+                    borderRadius: 'var(--radius-sm)',
+                    background: 'var(--bg-input)',
+                    color: 'var(--text-primary)',
+                    fontSize: '14px',
+                    boxSizing: 'border-box'
+                  }}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(prev => !prev)}
+                  style={{
+                    position: 'absolute',
+                    right: '10px',
+                    top: '50%',
+                    transform: 'translateY(-50%)',
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    fontSize: '16px',
+                    color: 'var(--text-muted)'
+                  }}
+                >
+                  {showPassword ? '🙈' : '🐵'}
+                </button>
+              </div>
+            </div>
+
+            <div style={{ marginBottom: '1.5rem' }}>
+              <label style={{
+                display: 'block',
+                fontSize: '13px',
+                color: 'var(--text-secondary)',
+                marginBottom: '6px'
+              }}>
+                Confirm Password
+              </label>
+              <input
+                type={showPassword ? 'text' : 'password'}
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                placeholder="Repeat your new password"
+                style={{
+                  width: '100%',
+                  padding: '10px',
+                  border: '1px solid var(--border)',
+                  borderRadius: 'var(--radius-sm)',
+                  background: 'var(--bg-input)',
+                  color: 'var(--text-primary)',
+                  fontSize: '14px',
+                  boxSizing: 'border-box'
+                }}
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading}
+              style={{
+                width: '100%',
+                padding: '11px',
+                background: 'var(--accent)',
+                color: 'var(--accent-text)',
+                border: 'none',
+                borderRadius: 'var(--radius-sm)',
+                fontSize: '14px',
+                fontWeight: '500',
+                cursor: loading ? 'not-allowed' : 'pointer',
+                opacity: loading ? 0.7 : 1
+              }}
+            >
+              {loading ? 'Resetting...' : 'Reset Password'}
+            </button>
+          </form>
+        </>
+      )}
+    </div>
+  )
+}

--- a/server/.env.example
+++ b/server/.env.example
@@ -2,5 +2,6 @@
 DATABASE_URL="postgresql://USER:PASSWORD@localhost:5432/food_log_db"
 JWT_SECRET="your-secret-key-here"
 USDA_API_KEY="your-usda-api-key-here"
+RESEND_API_KEY="your-resend-api-key-here"
 CLIENT_URL="http://localhost:5173"
 PORT=3000

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,10 +18,14 @@
         "express-rate-limit": "^8.3.1",
         "jsonwebtoken": "^9.0.3",
         "prisma": "^7.5.0",
+        "resend": "^6.12.3",
         "zod": "^4.3.6"
       },
       "devDependencies": {
         "nodemon": "^3.1.14"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
@@ -286,6 +290,12 @@
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -919,6 +929,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -1951,6 +1967,12 @@
         "pathe": "^2.0.3"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postgres": {
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
@@ -2193,6 +2215,27 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/remeda"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.3.tgz",
+      "integrity": "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.92.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/retry": {
@@ -2457,6 +2500,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2483,6 +2536,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.92.2",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/tinyexec": {

--- a/server/package.json
+++ b/server/package.json
@@ -24,6 +24,7 @@
     "express-rate-limit": "^8.3.1",
     "jsonwebtoken": "^9.0.3",
     "prisma": "^7.5.0",
+    "resend": "^6.12.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/server/prisma/migrations/20260509210726_add_password_reset_token/migration.sql
+++ b/server/prisma/migrations/20260509210726_add_password_reset_token/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "PasswordResetToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "used" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PasswordResetToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PasswordResetToken_token_key" ON "PasswordResetToken"("token");
+
+-- AddForeignKey
+ALTER TABLE "PasswordResetToken" ADD CONSTRAINT "PasswordResetToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   foodLogs  FoodLog[]
   waterLogs WaterLog[]
   savedMeal SavedMeal[]
+  passwordResetToken PasswordResetToken[]
 }
 
 model MacroGoal {
@@ -83,4 +84,15 @@ model SavedMealItem {
   fat         Float
 
   savedMeal SavedMeal @relation(fields: [savedMealId], references: [id], onDelete: Cascade)
+}
+
+model PasswordResetToken {
+  id          String @id @default(uuid())
+  userId      String
+  token       String @unique
+  expiresAt   DateTime
+  used        Boolean @default(false)
+  createdAt   DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id])
 }

--- a/server/src/controllers/auth.js
+++ b/server/src/controllers/auth.js
@@ -1,6 +1,8 @@
 import bcryp from 'bcrypt' 
 import jwt from 'jsonwebtoken' 
-import prisma from '../prisma.js' 
+import prisma from '../prisma.js'
+import crypto from 'crypto'
+import { sendPasswordResetEmail } from '../utils/email.js'
 
 export const register = async (req, res) => {
     try {
@@ -94,5 +96,83 @@ export const login = async (req, res) => {
     } catch (err) {
         console.error(err)
         res.status(500).json({ error: 'Login failed' })
+    }
+}
+
+export const forgotPassword = async (req, res) => {
+    try {
+
+        const { email } = req.body
+
+        const user = await prisma.user.findUnique({ where: { email } })
+
+        if (!user) {
+            return res.json({ message: 'If that email exists you will receive a reset link shortly' })
+        }
+
+        await prisma.passwordResetToken.updateMany({
+            where: { userId: user.id, used: false },
+            data: { used: true }
+        })
+
+        const token = crypto.randomBytes(32).toString('hex')
+        const expiresAt = new Date(Date.now() + 60 * 60 * 1000) // 1 hour
+
+        await prisma.passwordResetToken.create({
+            data: {
+                userId: user.id,
+                token,
+                expiresAt
+            }
+        })
+
+        await sendPasswordResetEmail(user.email, user.name, token)
+
+        res.json({ message: 'If that email exists you will receive a reset link shortly' })
+        
+    } catch (err) {
+        console.error(err)
+        res.send(500).json({ message: 'Failed to process reqeust' })
+    }
+}
+
+export const resetPassword = async (req, res) => {
+    try {
+        const { token, password } = req.body
+
+        const resetToken = await prisma.passwordResetToken.findUnique({
+            where: { token }, 
+            include: { user: true }
+        })
+
+        if (!resetToken) {
+            return res.status(400).json({ error: 'Invalid or expired reset link' })
+        }
+
+        if (resetToken.used) {
+            return res.status(400).json({ error: 'Reset link already been used' })
+        }
+
+        if (resetToken.expiresAt < new Date()) {
+            return res.status(400).json({ error: 'Reset link has expired' })
+        }
+
+        const hashedPassword = await bcryp.hash(password, 10)
+
+        await prisma.user.update({
+            where: { id: resetToken.userId },
+            data: { password: hashedPassword }
+        })
+
+        await prisma.passwordResetToken.update({ 
+            where: { token }, 
+            data: { used: true }
+        })
+
+        res.json({ message: 'Password reset successfully' })
+        
+    } catch (err) {
+        console.error(err)
+        res.send(500).json({ message: 'Failed to process request' })
     }
 }

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -1,11 +1,13 @@
 import { Router } from 'express' 
-import { register, login } from '../controllers/auth.js' 
+import { register, login, forgotPassword, resetPassword } from '../controllers/auth.js' 
 import { validate } from '../middleware/validate.js'
-import { registerSchema, loginSchema } from '../validators/auth.js'
+import { registerSchema, loginSchema, forgotPasswordSchema, resetPasswordSchema } from '../validators/auth.js'
 
 const router = Router() 
 
 router.post('/register', validate(registerSchema), register) 
-router.post('/login', validate(loginSchema), login) 
+router.post('/login', validate(loginSchema), login)
+router.post('/forgot-password', validate(forgotPasswordSchema), forgotPassword)
+router.post('/reset-password', validate(resetPasswordSchema), resetPassword)
 
 export default router 

--- a/server/src/utils/email.js
+++ b/server/src/utils/email.js
@@ -1,0 +1,32 @@
+import { Resend } from 'resend' 
+
+const resend = new Resend(process.env.RESEND_API_KEY)
+
+export const sendPasswordResetEmail = async (email, name, resetToken) => {
+    const resetUrl = `${process.env.CLIENT_URL}/reset-password?token=${resetToken}`
+
+    await resend.emails.send({
+        from: 'Chomp Tracker <noreply@noreply.chomptracker.com>',
+        to: email,
+        subject: 'Reset your Chomp Tracker password',
+        html: `
+            <div style='font-family: Arial, sans-serif; max-width: 480px; margin: 0 auto;'>
+                <h2 style='color: #1F4E79;'>🥗 Chomp Tracker</h2>
+                <p>We received a request to reset your password. Click the button below to create a new one:</p>
+                <a href='${resetUrl}'
+                    style='display: inline-block; padding: 12px 24px; background: #2E75B6; 
+                    color: white; text-decoration: none; border-radius: 6px; 
+                    font-weight: 500; margin: 16px 0;'>
+                    Reset Password
+                </a>
+                <p style='color: #888; font-size: 13px;'>
+                    This link expires in 1 hour. If you didn't request a password reset
+                    you can safely ignore this email.
+                </p>
+                <p style='color: #888; font-size: 12px'>
+                    Or copy this link: ${resetUrl}
+                </p>
+            </div>
+        `
+    })
+}

--- a/server/src/validators/auth.js
+++ b/server/src/validators/auth.js
@@ -11,3 +11,12 @@ export const loginSchema = z.object({
     email: z.email('Invalid email address'), 
     password: z.string().min(1, 'Password is required') 
 })
+
+export const forgotPasswordSchema = z.object({
+    email: z.email('Invalid email address')
+})
+
+export const resetPasswordSchema = z.object({
+    token: z.string().min(1, 'Token is required'),
+    password: z.string().min(6, 'Password must be at least 6 characters')
+})


### PR DESCRIPTION
## Feature: Password Reset with Email

### New Features
- Forgot Password page — user enters email and receives 
  a reset link via Resend email service
- Reset Password page — user enters new password with 
  confirm password field and show/hide toggle
- "Forgot password?" link added to login page
- Auto-redirect to login 3 seconds after successful reset

### Backend
- New POST /api/auth/forgot-password route
  → validates email, generates secure 32-char hex token
  → stores token in DB with 1 hour expiry
  → invalidates any previous unused tokens
  → sends branded email via Resend
- New POST /api/auth/reset-password route  
  → validates token exists, not expired, not used
  → updates password hash with bcrypt
  → marks token as used

### Database
- New PasswordResetToken table
  → id, userId, token, expiresAt, used, createdAt
  → migration: 20260509210726_add_password_reset_token

### Security
- Email enumeration prevention — always returns same 
  success message whether email exists or not
- Tokens expire after 1 hour
- Tokens are single use — marked used after reset
- Previous tokens invalidated on new request

### Infrastructure
- Resend email service integrated
- Sending from noreply@noreply.chomptracker.com
- RESEND_API_KEY added to Railway environment variables