### PR TITLE
Feature/ai food logging

### DIFF
--- a/client/src/api/foods.js
+++ b/client/src/api/foods.js
@@ -20,9 +20,9 @@ export const searchFoods = async (query) => {
     return response.data 
 }
 
-export const moveFoodEntry = async (id, meal) => {
-    const response = await axiosClient.patch(`/api/foods/${id}`, { meal })
-    return response.data
+export const updateFoodEntry = async (id, data) => {
+  const response = await axiosClient.patch(`/api/foods/${id}`, data)
+  return response.data
 }
 
 export const copyMealFromYesterday = async (date, meal) => {

--- a/client/src/components/MealSection.jsx
+++ b/client/src/components/MealSection.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useDeleteFood, useMoveFood, useCopyMeal } from '../hooks/useDailyLog.js'
+import { useDeleteFood, useCopyMeal, useUpdateFood } from '../hooks/useDailyLog.js'
 
 const mealEmojis = {
   breakfast: '🌅',
@@ -19,18 +19,20 @@ const meals = ['breakfast', 'lunch', 'dinner', 'snack']
 
 export default function MealSection({ meal, entries = [], totals, date, onAddClick }) {
   const deleteFood = useDeleteFood(date)
-  const moveFood = useMoveFood(date)
+  const updateFood = useUpdateFood(date)
   const copyMeal = useCopyMeal(date)
 
   const [movingEntry, setMovingEntry] = useState(null)
   const [showCopyConfirm, setShowCopyConfirm] = useState(false)
   const [copySuccess, setCopySuccess] = useState(false)
   const [copyError, setCopyError] = useState(false)
+  const [editingEntry, setEditingEntry] = useState(null)
+  const [editValues, setEditValues] = useState({})
 
   const isEmpty = entries.length === 0
 
   const handleMove = (id, newMeal) => {
-    moveFood.mutate({ id, meal: newMeal })
+    updateFood.mutate({ id, meal: newMeal })
     setMovingEntry(null)
   }
 
@@ -48,6 +50,39 @@ export default function MealSection({ meal, entries = [], totals, date, onAddCli
       }
     })
   }
+
+  const handleEditStart = (entry) => {
+  setEditingEntry(entry.id)
+  setEditValues({
+    foodName:    entry.foodName,
+    servingSize: entry.servingSize,
+    servingUnit: entry.servingUnit,
+    calories:    entry.calories,
+    protein:     entry.protein,
+    carbs:       entry.carbs,
+    fat:         entry.fat
+  })
+}
+
+const handleEditSave = (id) => {
+  updateFood.mutate({
+    id,
+    foodName:    editValues.foodName,
+    servingSize: Number(editValues.servingSize),
+    servingUnit: editValues.servingUnit,
+    calories:    Number(editValues.calories),
+    protein:     Number(editValues.protein),
+    carbs:       Number(editValues.carbs),
+    fat:         Number(editValues.fat)
+  }, {
+    onSuccess: () => setEditingEntry(null)
+  })
+}
+
+const handleEditCancel = () => {
+  setEditingEntry(null)
+  setEditValues({})
+}
 
   return (
     <div style={{
@@ -184,17 +219,17 @@ export default function MealSection({ meal, entries = [], totals, date, onAddCli
 
       {/* Food entries */}
       {entries.map(entry => (
-        <div
-          key={entry.id}
-          style={{
-            borderBottom: '1px solid var(--border)',
-          }}
-        >
+      <div
+        key={entry.id}
+        style={{ borderBottom: '1px solid var(--border)' }}
+      >
+        {/* Normal view */}
+        {editingEntry !== entry.id && (
           <div style={{
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
-            padding: '10px 16px',
+            padding: '10px 16px'
           }}>
             <div>
               <div style={{
@@ -210,8 +245,23 @@ export default function MealSection({ meal, entries = [], totals, date, onAddCli
               </div>
             </div>
 
-            {/* Action buttons */}
             <div style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+              {/* Edit button */}
+              <button
+                onClick={() => handleEditStart(entry)}
+                title="Edit entry"
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  cursor: 'pointer',
+                  color: 'var(--text-muted)',
+                  fontSize: '13px',
+                  padding: '4px'
+                }}
+              >
+                ✏️ <span className="icon-label">Edit</span>
+              </button>
+
               {/* Move button */}
               <button
                 onClick={() => setMovingEntry(movingEntry === entry.id ? null : entry.id)}
@@ -225,7 +275,7 @@ export default function MealSection({ meal, entries = [], totals, date, onAddCli
                   padding: '4px'
                 }}
               >
-                ↕ <span className='icon-label'>Move Food</span>
+                ↕ <span className="icon-label">Move Food</span>
               </button>
 
               {/* Delete button */}
@@ -245,62 +295,168 @@ export default function MealSection({ meal, entries = [], totals, date, onAddCli
               </button>
             </div>
           </div>
+        )}
 
-          {/* Move meal picker — shows inline when ↕ clicked */}
-          {movingEntry === entry.id && (
+        {/* Edit view */}
+        {editingEntry === entry.id && (
+          <div style={{ padding: '12px 16px' }}>
+            {/* Food name */}
+            <input
+              value={editValues.foodName}
+              onChange={(e) => setEditValues(prev => ({ ...prev, foodName: e.target.value }))}
+              style={{
+                width: '100%',
+                padding: '8px',
+                border: '1px solid var(--border)',
+                borderRadius: 'var(--radius-sm)',
+                background: 'var(--bg-input)',
+                color: 'var(--text-primary)',
+                fontSize: '13px',
+                fontWeight: '500',
+                marginBottom: '10px',
+                boxSizing: 'border-box'
+              }}
+            />
+
+            {/* Macro fields */}
             <div style={{
-              padding: '8px 16px 12px',
-              background: 'var(--bg-secondary)',
-              borderTop: '1px solid var(--border)'
+              display: 'grid',
+              gridTemplateColumns: 'repeat(5, 1fr)',
+              gap: '8px',
+              marginBottom: '10px'
             }}>
-              <div style={{
-                fontSize: '11px',
-                color: 'var(--text-muted)',
-                marginBottom: '8px'
-              }}>
-                Move to:
-              </div>
-              <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
-                {meals.filter(m => m !== meal).map(m => (
-                  <button
-                    key={m}
-                    onClick={() => handleMove(entry.id, m)}
-                    disabled={moveFood.isPending}
+              {[
+                { label: 'Serving', field: 'servingSize', color: 'var(--text-primary)' },
+                { label: 'Cal',     field: 'calories',    color: 'var(--error)' },
+                { label: 'Protein', field: 'protein',     color: 'var(--success)' },
+                { label: 'Carbs',   field: 'carbs',       color: 'var(--warning)' },
+                { label: 'Fat',     field: 'fat',         color: 'var(--purple)' }
+              ].map(macro => (
+                <div key={macro.field} style={{ textAlign: 'center' }}>
+                  <div style={{
+                    fontSize: '11px',
+                    color: 'var(--text-muted)',
+                    marginBottom: '4px'
+                  }}>
+                    {macro.label}
+                  </div>
+                  <input
+                    type="number"
+                    value={editValues[macro.field]}
+                    onChange={(e) => setEditValues(prev => ({
+                      ...prev,
+                      [macro.field]: e.target.value
+                    }))}
+                    onFocus={(e) => e.target.select()}
                     style={{
-                      padding: '5px 12px',
-                      background: 'var(--bg-primary)',
+                      width: '100%',
+                      padding: '6px 4px',
                       border: '1px solid var(--border)',
                       borderRadius: 'var(--radius-sm)',
-                      fontSize: '12px',
-                      cursor: 'pointer',
-                      color: 'var(--text-primary)',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: '4px'
+                      background: 'var(--bg-input)',
+                      color: macro.color,
+                      fontSize: '13px',
+                      fontWeight: '600',
+                      textAlign: 'center'
                     }}
-                  >
-                    {mealEmojis[m]} {m}
-                  </button>
-                ))}
+                  />
+                </div>
+              ))}
+            </div>
+
+            {/* Save / Cancel */}
+            <div style={{ display: 'flex', gap: '8px' }}>
+              <button
+                onClick={handleEditCancel}
+                style={{
+                  flex: 1,
+                  padding: '7px',
+                  background: 'none',
+                  border: '1px solid var(--border)',
+                  borderRadius: 'var(--radius-sm)',
+                  fontSize: '12px',
+                  cursor: 'pointer',
+                  color: 'var(--text-secondary)'
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => handleEditSave(entry.id)}
+                disabled={updateFood.isPending}
+                style={{
+                  flex: 2,
+                  padding: '7px',
+                  background: 'var(--accent)',
+                  color: 'var(--accent-text)',
+                  border: 'none',
+                  borderRadius: 'var(--radius-sm)',
+                  fontSize: '12px',
+                  fontWeight: '500',
+                  cursor: 'pointer'
+                }}
+              >
+                {updateFood.isPending ? 'Saving...' : '✓ Save changes'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Move meal picker */}
+        {movingEntry === entry.id && editingEntry !== entry.id && (
+          <div style={{
+            padding: '8px 16px 12px',
+            background: 'var(--bg-secondary)',
+            borderTop: '1px solid var(--border)'
+          }}>
+            <div style={{
+              fontSize: '11px',
+              color: 'var(--text-muted)',
+              marginBottom: '8px'
+            }}>
+              Move to:
+            </div>
+            <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap' }}>
+              {meals.filter(m => m !== meal).map(m => (
                 <button
-                  onClick={() => setMovingEntry(null)}
+                  key={m}
+                  onClick={() => handleMove(entry.id, m)}
+                  disabled={updateFood.isPending}
                   style={{
                     padding: '5px 12px',
-                    background: 'none',
+                    background: 'var(--bg-primary)',
                     border: '1px solid var(--border)',
                     borderRadius: 'var(--radius-sm)',
                     fontSize: '12px',
                     cursor: 'pointer',
-                    color: 'var(--text-muted)'
+                    color: 'var(--text-primary)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '4px'
                   }}
                 >
-                  Cancel
+                  {mealEmojis[m]} {m}
                 </button>
-              </div>
+              ))}
+              <button
+                onClick={() => setMovingEntry(null)}
+                style={{
+                  padding: '5px 12px',
+                  background: 'none',
+                  border: '1px solid var(--border)',
+                  borderRadius: 'var(--radius-sm)',
+                  fontSize: '12px',
+                  cursor: 'pointer',
+                  color: 'var(--text-muted)'
+                }}
+              >
+                Cancel
+              </button>
             </div>
-          )}
-        </div>
-      ))}
+          </div>
+        )}
+      </div>
+    ))}
 
       {/* Add food button */}
       <button

--- a/client/src/hooks/useDailyLog.js
+++ b/client/src/hooks/useDailyLog.js
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query' 
-import { getFoodLog, addFoodEntry, deleteFoodEntry, moveFoodEntry, copyMealFromYesterday } from '../api/foods.js' 
+import { getFoodLog, addFoodEntry, deleteFoodEntry, updateFoodEntry, copyMealFromYesterday } from '../api/foods.js' 
 
 export function useFoodLog(date) {
     return useQuery({
@@ -35,10 +35,10 @@ export function useDeleteFood(date) {
   })
 }
 
-export function useMoveFood(date) {
+export function useUpdateFood(date) {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: ({ id, meal }) => moveFoodEntry(id, meal),
+    mutationFn: ({ id, ...data }) => updateFoodEntry(id, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['summary', date] })
       queryClient.refetchQueries({ queryKey: ['summary', date] })

--- a/server/src/controllers/ai.js
+++ b/server/src/controllers/ai.js
@@ -101,7 +101,7 @@ export const parseFoodDescription = async (req, res) => {
         res.json({ foods: foodEntries })
 
     } catch (err) {
-        console.error('AI parse error:', err)
-        res.status(500).json({ error: 'AI service unavailable. Please try agian.' })
+        console.error('AI parse error:', err.message)
+        res.status(500).json({ error: 'AI service unavailable. Please try again.' })
     }
 }

--- a/server/src/controllers/foods.js
+++ b/server/src/controllers/foods.js
@@ -79,31 +79,35 @@ export const deleteFoodEntry = async (req, res) => {
     }
 }
 
-export const moveFoodEntry = async (req, res) => {
-    try {
-        const { id } = req.params
-        const { meal } = req.body
+export const updateFoodEntry = async (req, res) => {
+  try {
+    const { id } = req.params
+    const { meal, foodName, servingSize, servingUnit, calories, protein, carbs, fat } = req.body
 
-        const entry = await prisma.foodLog.findUnique({ where: { id } })
+    const entry = await prisma.foodLog.findUnique({ where: { id } })
 
-        if (!entry) {
-            return res.status(404).json({ error: 'Entry not found' })
-        }
+    if (!entry) return res.status(404).json({ error: 'Entry not found' })
+    if (entry.userId !== req.user.userId) return res.status(403).json({ error: 'Not authorized' })
 
-        if (entry.userId !== req.user.userId) {
-            return res.status(403).json({ error: 'Not authorized' })
-        }
+    const updated = await prisma.foodLog.update({
+      where: { id },
+      data: {
+        ...(meal && { meal }),
+        ...(foodName && { foodName }),
+        ...(servingSize !== undefined && { servingSize: Number(servingSize) }),
+        ...(servingUnit && { servingUnit }),
+        ...(calories !== undefined && { calories: Number(calories) }),
+        ...(protein !== undefined && { protein: Number(protein) }),
+        ...(carbs !== undefined && { carbs: Number(carbs) }),
+        ...(fat !== undefined && { fat: Number(fat) })
+      }
+    })
 
-        const updated = await prisma.foodLog.update({
-            where: { id }, 
-            data: { meal }
-        })
-
-        res.json({ message: 'Food moved', entry: updated })
-    } catch (err) {
-        console.error(err)
-        res.status(500).json({ error: 'Failed to move food entry' })
-    }
+    res.json({ message: 'Food updated', entry: updated })
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({ error: 'Failed to update food entry' })
+  }
 }
 
 export const copyMealFromYesterday = async (req, res) => {

--- a/server/src/routes/ai.js
+++ b/server/src/routes/ai.js
@@ -1,5 +1,5 @@
 import { Router } from 'express'
-import { rateLimit } from 'express-rate-limit'
+import { rateLimit, ipKeyGenerator } from 'express-rate-limit'
 import { parseFoodDescription } from '../controllers/ai.js'
 import { authenticateToken } from '../middleware/auth.js'
 import { validate } from '../middleware/validate.js'
@@ -12,7 +12,7 @@ const parseFoodSchema = z.object({
 const aiLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 min
   max: 10,             // max 10 AI requests per minute per user
-  keyGenerator: (req) => req.user?.userId || req.ip,
+  keyGenerator: (req) => req.user?.userId || ipKeyGenerator(req),
   message: { error: 'Too many AI requests, please slow down' }
 })
 

--- a/server/src/routes/foods.js
+++ b/server/src/routes/foods.js
@@ -1,8 +1,8 @@
 import { Router } from 'express' 
-import { getFoodLog, addFoodLog, deleteFoodEntry,moveFoodEntry, copyMealFromYesterday } from '../controllers/foods.js' 
+import { getFoodLog, addFoodLog, deleteFoodEntry, updateFoodEntry, copyMealFromYesterday } from '../controllers/foods.js' 
 import { authenticateToken } from '../middleware/auth.js'
 import { validate } from '../middleware/validate.js'
-import { foodEntrySchema, moveFoodSchema, copyMealSchema } from '../validators/foods.js'
+import { foodEntrySchema, updateFoodSchema, copyMealSchema } from '../validators/foods.js'
 
 const router = Router() 
 
@@ -10,6 +10,6 @@ router.get('/:date', authenticateToken, getFoodLog)
 router.post('/', authenticateToken, validate(foodEntrySchema), addFoodLog) 
 router.post('/copy', authenticateToken, validate(copyMealSchema), copyMealFromYesterday)
 router.delete('/:id', authenticateToken, deleteFoodEntry)
-router.patch('/:id', authenticateToken, validate(moveFoodSchema), moveFoodEntry)
+router.patch('/:id', authenticateToken, validate(updateFoodSchema), updateFoodEntry)
 
 export default router

--- a/server/src/validators/foods.js
+++ b/server/src/validators/foods.js
@@ -16,8 +16,19 @@ export const foodEntrySchema = z.object({
     fat: z.number().nonnegative('Fat must be 0 or more')
 })
 
-export const moveFoodSchema = z.object({
-    meal: z.enum(['breakfast', 'lunch', 'dinner', 'snack'])
+export const updateFoodSchema = z.object({
+  meal: z.enum(['breakfast', 'lunch', 'dinner', 'snack']).optional(),
+  foodName: z.string().min(1).max(100).optional(),
+  servingSize: z.number().positive().optional(),
+  servingUnit: z.enum([
+    'g', 'oz', 'cup', 'tbsp', 'tsp',
+    'whole', 'piece', 'slice', 'bar',
+    'links', 'link', 'serving', 'ml', 'l'
+  ]).optional(),
+  calories: z.number().nonnegative().optional(),
+  protein: z.number().nonnegative().optional(),
+  carbs: z.number().nonnegative().optional(),
+  fat: z.number().nonnegative().optional()
 })
 
 export const copyMealSchema = z.object({


### PR DESCRIPTION
## Feature: Inline Edit for Logged Food Entries

### What it does
Users can edit any field on a logged food entry directly 
from the dashboard — food name, serving size, and all 
macros (calories, protein, carbs, fat).

### Use case
User logs 1 scrambled egg then realizes they had 2 — 
instead of deleting and re-adding, they tap ✏️ Edit, 
update the values, and save.

### Backend
- Updated PATCH /api/foods/:id to accept all food fields
- updateFoodEntry replaces moveFoodEntry (handles both 
  meal moves and field updates in one endpoint)
- New updateFoodSchema with all fields optional

### Frontend
- ✏️ Edit button on each food entry in MealSection
- Inline edit mode with food name + macro fields
- onFocus selects value for quick editing
- Save → updates dashboard macros instantly
- Cancel → returns to normal view
- Works alongside existing Move and Delete actions