### PR TITLE
Feature/change password

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import SavedMealsPage from './pages/SavedMealsPage.jsx'
 import CreateSavedMealPage from './pages/CreateSavedMealPage.jsx'
 import ForgotPasswordPage from './pages/ForgotPasswordPage.jsx'
 import ResetPasswordPage from './pages/ResetPasswordPage.jsx'
+import SettingsPage from './pages/SettingsPage.jsx'
 
 function ProtectedRoute({ children }) {
   const { user, loading } = useAuth()
@@ -64,6 +65,13 @@ export default function App() {
           </ProtectedRoute>
         } />
       <Route path='*' element={<Navigate to='/login' replace />}/>
+      <Route path='/settings' element={
+        <ProtectedRoute>
+          <ProtectedLayout>
+            <SettingsPage />
+          </ProtectedLayout>
+        </ProtectedRoute>
+      } />
     </Routes>
   )
 }

--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -128,6 +128,20 @@ export default function NavBar() {
                 >
                     Logout
                 </button>
+                {/* Settings link */}
+                <Link
+                    to="/settings"
+                    style={{
+                        fontSize: '13px',
+                        color: 'var(--text-secondary)',
+                        textDecoration: 'none',
+                        padding: '6px 10px',
+                        borderRadius: 'var(--radius-sm)',
+                        border: '1px solid var(--border)'
+                    }}
+                >
+                    ⚙️ <span className="icon-label">Settings</span>
+                </Link>
             </div>
         </nav>
     )

--- a/client/src/pages/SettingsPage.jsx
+++ b/client/src/pages/SettingsPage.jsx
@@ -1,0 +1,276 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import axios from 'axios'
+import { useAuth } from '../context/AuthContext.jsx'
+
+export default function SettingsPage() {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [showPasswords, setShowPasswords] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [success, setSuccess] = useState(false)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError(null)
+    setSuccess(false)
+
+    if (newPassword !== confirmPassword) {
+      return setError('New passwords do not match')
+    }
+
+    if (newPassword.length < 6) {
+      return setError('New password must be at least 6 characters')
+    }
+
+    if (currentPassword === newPassword) {
+      return setError('New password must be different from current password')
+    }
+
+    setLoading(true)
+    try {
+        await axios.post(
+            `${import.meta.env.VITE_API_URL}/api/auth/change-password`,
+            { currentPassword, newPassword },
+            {
+                headers: {
+                Authorization: `Bearer ${localStorage.getItem('token')}`
+                }
+            }
+        )
+      setSuccess(true)
+      setCurrentPassword('')
+      setNewPassword('')
+      setConfirmPassword('')
+    } catch (err) {
+      setError(err.response?.data?.error || 'Failed to change password')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: '480px', margin: '0 auto' }}>
+      {/* Header */}
+      <div style={{
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: '1.5rem'
+      }}>
+        <div>
+          <h2 style={{
+            fontSize: '18px',
+            fontWeight: '600',
+            color: 'var(--text-primary)',
+            marginBottom: '4px'
+          }}>
+            Settings
+          </h2>
+          <p style={{
+            fontSize: '13px',
+            color: 'var(--text-muted)'
+          }}>
+            {user?.email}
+          </p>
+        </div>
+        <button
+          onClick={() => navigate('/dashboard')}
+          style={{
+            background: 'none',
+            border: '1px solid var(--border)',
+            borderRadius: 'var(--radius-sm)',
+            padding: '6px 12px',
+            cursor: 'pointer',
+            color: 'var(--text-secondary)',
+            fontSize: '13px'
+          }}
+        >
+          ← Back
+        </button>
+      </div>
+
+      {/* Change Password Card */}
+      <div style={{
+        background: 'var(--bg-primary)',
+        border: '1px solid var(--border)',
+        borderRadius: 'var(--radius-lg)',
+        overflow: 'hidden'
+      }}>
+        <div style={{
+          padding: '14px 16px',
+          borderBottom: '1px solid var(--border)',
+          background: 'var(--bg-secondary)',
+          fontSize: '13px',
+          fontWeight: '600',
+          color: 'var(--text-primary)'
+        }}>
+          Change Password
+        </div>
+
+        <div style={{ padding: '16px' }}>
+          {/* Success message */}
+          {success && (
+            <div style={{
+              padding: '12px',
+              background: 'rgba(29,158,117,0.1)',
+              border: '1px solid var(--success)',
+              borderRadius: 'var(--radius-sm)',
+              color: 'var(--success)',
+              fontSize: '13px',
+              marginBottom: '16px'
+            }}>
+              ✓ Password changed successfully!
+            </div>
+          )}
+
+          {/* Error message */}
+          {error && (
+            <div style={{
+              padding: '12px',
+              background: 'rgba(226,75,74,0.1)',
+              border: '1px solid var(--error)',
+              borderRadius: 'var(--radius-sm)',
+              color: 'var(--error)',
+              fontSize: '13px',
+              marginBottom: '16px'
+            }}>
+              {error}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit}>
+            {/* Current password */}
+            <div style={{ marginBottom: '12px' }}>
+              <label style={{
+                display: 'block',
+                fontSize: '13px',
+                color: 'var(--text-secondary)',
+                marginBottom: '6px'
+              }}>
+                Current Password
+              </label>
+              <div style={{ position: 'relative' }}>
+                <input
+                  type={showPasswords ? 'text' : 'password'}
+                  value={currentPassword}
+                  onChange={(e) => setCurrentPassword(e.target.value)}
+                  required
+                  style={{
+                    width: '100%',
+                    padding: '10px 40px 10px 10px',
+                    border: '1px solid var(--border)',
+                    borderRadius: 'var(--radius-sm)',
+                    background: 'var(--bg-input)',
+                    color: 'var(--text-primary)',
+                    fontSize: '14px',
+                    boxSizing: 'border-box'
+                  }}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPasswords(prev => !prev)}
+                  style={{
+                    position: 'absolute',
+                    right: '10px',
+                    top: '50%',
+                    transform: 'translateY(-50%)',
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    fontSize: '16px',
+                    color: 'var(--text-muted)'
+                  }}
+                >
+                  {showPasswords ? '🙈' : '🐵'}
+                </button>
+              </div>
+            </div>
+
+            {/* New password */}
+            <div style={{ marginBottom: '12px' }}>
+              <label style={{
+                display: 'block',
+                fontSize: '13px',
+                color: 'var(--text-secondary)',
+                marginBottom: '6px'
+              }}>
+                New Password
+              </label>
+              <input
+                type={showPasswords ? 'text' : 'password'}
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+                required
+                placeholder="At least 6 characters"
+                style={{
+                  width: '100%',
+                  padding: '10px',
+                  border: '1px solid var(--border)',
+                  borderRadius: 'var(--radius-sm)',
+                  background: 'var(--bg-input)',
+                  color: 'var(--text-primary)',
+                  fontSize: '14px',
+                  boxSizing: 'border-box'
+                }}
+              />
+            </div>
+
+            {/* Confirm new password */}
+            <div style={{ marginBottom: '20px' }}>
+              <label style={{
+                display: 'block',
+                fontSize: '13px',
+                color: 'var(--text-secondary)',
+                marginBottom: '6px'
+              }}>
+                Confirm New Password
+              </label>
+              <input
+                type={showPasswords ? 'text' : 'password'}
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                required
+                placeholder="Repeat new password"
+                style={{
+                  width: '100%',
+                  padding: '10px',
+                  border: '1px solid var(--border)',
+                  borderRadius: 'var(--radius-sm)',
+                  background: 'var(--bg-input)',
+                  color: 'var(--text-primary)',
+                  fontSize: '14px',
+                  boxSizing: 'border-box'
+                }}
+              />
+            </div>
+
+            <button
+              type="submit"
+              disabled={loading}
+              style={{
+                width: '100%',
+                padding: '11px',
+                background: 'var(--accent)',
+                color: 'var(--accent-text)',
+                border: 'none',
+                borderRadius: 'var(--radius-sm)',
+                fontSize: '14px',
+                fontWeight: '500',
+                cursor: loading ? 'not-allowed' : 'pointer',
+                opacity: loading ? 0.7 : 1
+              }}
+            >
+              {loading ? 'Changing...' : 'Change Password'}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/server/src/controllers/auth.js
+++ b/server/src/controllers/auth.js
@@ -176,3 +176,31 @@ export const resetPassword = async (req, res) => {
         res.send(500).json({ message: 'Failed to process request' })
     }
 }
+
+export const changePassword = async (req, res) => {
+    try {
+        const { currentPassword, newPassword } = req.body
+        const userId = req.user.userId
+
+        const user = await prisma.user.findUnique({ where: { id: userId } })
+        if (!user) return res.status(404).json({ error: 'User not found' })
+
+        // Verify current password
+        const match = await bcryp.compare(currentPassword, user.password)
+        if (!match) return res.status(401).json({ error: 'Current password is incorrect' })
+
+        // Hash new password
+        const hashedPassword = await bcryp.hash(newPassword, 10)
+
+        // Update password
+        await prisma.user.update({
+            where: { id: userId },
+            data: { password: hashedPassword }
+        })
+
+        res.json({ message: 'Password changed successfully' })
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({ error: 'Failed to change password' })
+    }
+}

--- a/server/src/routes/auth.js
+++ b/server/src/routes/auth.js
@@ -1,7 +1,8 @@
 import { Router } from 'express' 
-import { register, login, forgotPassword, resetPassword } from '../controllers/auth.js' 
+import { register, login, forgotPassword, resetPassword, changePassword } from '../controllers/auth.js'
+import { authenticateToken } from '../middleware/auth.js'
 import { validate } from '../middleware/validate.js'
-import { registerSchema, loginSchema, forgotPasswordSchema, resetPasswordSchema } from '../validators/auth.js'
+import { registerSchema, loginSchema, forgotPasswordSchema, resetPasswordSchema, changePasswordSchema } from '../validators/auth.js'
 
 const router = Router() 
 
@@ -9,5 +10,6 @@ router.post('/register', validate(registerSchema), register)
 router.post('/login', validate(loginSchema), login)
 router.post('/forgot-password', validate(forgotPasswordSchema), forgotPassword)
 router.post('/reset-password', validate(resetPasswordSchema), resetPassword)
+router.post('/change-password', authenticateToken, validate(changePasswordSchema), changePassword)
 
 export default router 

--- a/server/src/validators/auth.js
+++ b/server/src/validators/auth.js
@@ -20,3 +20,8 @@ export const resetPasswordSchema = z.object({
     token: z.string().min(1, 'Token is required'),
     password: z.string().min(6, 'Password must be at least 6 characters')
 })
+
+export const changePasswordSchema = z.object({
+    currentPassword: z.string().min(1, 'Current password is required'),
+    newPassword: z.string().min(6, 'New password must be at least 6 characters')
+})


### PR DESCRIPTION
## Feature: Change Password

### What it does
Logged in users can change their password from the 
Settings page without needing to log out.

### Backend
- New POST /api/auth/change-password route
- Verifies current password with bcrypt before updating
- Returns 401 if current password is incorrect
- Hashes new password before saving

### Frontend
- New Settings page at /settings
- Settings link in NavBar
- Current password + new password + confirm fields
- Show/hide password toggle
- Inline error and success messages
- Uses direct axios call (bypasses JWT interceptor 
  to prevent auto-logout on wrong password)

### Validation
- New password must be at least 6 characters
- New password must match confirm password
- New password must differ from current password
- Wrong current password shows error, keeps user logged in