### PR TITLE
feat: added serving size multiplier across food sear, saved meals, edit, and ChompAI

### DIFF
--- a/client/src/components/AIFoodLogger.jsx
+++ b/client/src/components/AIFoodLogger.jsx
@@ -285,6 +285,24 @@ export default function AIFoodLogger({ date, onClose }) {
 // Inline editable food card
 function FoodReviewCard({ food, onUpdate, onRemove }) {
   const [editing, setEditing] = useState(false)
+  const [servings, setServings] = useState(1)
+  const [baseValues] = useState({
+    servingSize: food.servingSize,
+    calories: food.calories,
+    protein: food.protein,
+    carbs: food.carbs,
+    fat: food.fat
+  })
+
+  const handleServingsChange = (newServings) => {
+    setServings(newServings)
+    onUpdate('servingSize', Math.round(baseValues.servingSize * newServings * 10) / 10)
+    onUpdate('calories',    Math.round(baseValues.calories    * newServings))
+    onUpdate('protein',     Math.round(baseValues.protein     * newServings * 10) / 10)
+    onUpdate('carbs',       Math.round(baseValues.carbs       * newServings * 10) / 10)
+    onUpdate('fat',         Math.round(baseValues.fat         * newServings * 10) / 10)
+
+  }
 
   return (
     <div style={{
@@ -356,6 +374,82 @@ function FoodReviewCard({ food, onUpdate, onRemove }) {
             Remove
           </button>
         </div>
+      </div>
+      {/* Servings multiplier */}
+      <div style={{
+        padding: '8px 12px',
+        borderBottom: '1px solid var(--border)',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px'
+      }}>
+        <span style={{
+          fontSize: '12px',
+          color: 'var(--text-muted)',
+          whiteSpace: 'nowrap'
+        }}>
+          Servings:
+        </span>
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--radius-sm)',
+          overflow: 'hidden'
+        }}>
+          <button
+            onClick={() => handleServingsChange(Math.max(0.5, Math.round((servings - 0.5) * 10) / 10))}
+            style={{
+              padding: '5px 10px',
+              background: 'var(--bg-secondary)',
+              border: 'none',
+              cursor: 'pointer',
+              color: 'var(--text-primary)',
+              fontSize: '14px',
+              fontWeight: '500'
+            }}
+          >
+            −
+          </button>
+          <input
+            type="number"
+            value={servings}
+            onChange={(e) => handleServingsChange(Math.max(0.5, Number(e.target.value)))}
+            onFocus={(e) => e.target.select()}
+            min="0.5"
+            step="0.5"
+            style={{
+              width: '45px',
+              padding: '5px 4px',
+              border: 'none',
+              background: 'var(--bg-input)',
+              color: 'var(--text-primary)',
+              fontSize: '13px',
+              fontWeight: '600',
+              textAlign: 'center'
+            }}
+          />
+          <button
+            onClick={() => handleServingsChange(Math.round((servings + 0.5) * 10) / 10)}
+            style={{
+              padding: '5px 10px',
+              background: 'var(--bg-secondary)',
+              border: 'none',
+              cursor: 'pointer',
+              color: 'var(--text-primary)',
+              fontSize: '14px',
+              fontWeight: '500'
+            }}
+          >
+            +
+          </button>
+        </div>
+        <span style={{
+          fontSize: '12px',
+          color: 'var(--text-muted)'
+        }}>
+          {servings === 1 ? '1 serving' : `${servings} servings`}
+        </span>
       </div>
 
       {/* Macros row */}

--- a/client/src/components/FoodSearch.jsx
+++ b/client/src/components/FoodSearch.jsx
@@ -4,7 +4,7 @@ import {useAddFood } from '../hooks/useDailyLog.js'
 
 const OZ_TO_G = 28.3495
 
-function calculateMacros(food, userServingSize, userServingUnit) {
+function calculateMacros(food, userServingSize, userServingUnit, servings = 1) {
     const userGrams = userServingUnit === 'oz' 
     ? userServingSize * OZ_TO_G 
     : userServingSize
@@ -13,7 +13,7 @@ function calculateMacros(food, userServingSize, userServingUnit) {
     ? (food.servingSize || 100) * OZ_TO_G
     : (food.servingSize || 100)
     
-    const ratio = userGrams / baseGrams
+    const ratio = (userGrams / baseGrams) * servings
 
     return {
         calories: Math.round(food.calories * ratio),
@@ -30,6 +30,7 @@ export default function FoodSearch({ date, onClose, defaultMeal = 'snack' }) {
     const [selectedMeal, setSelectedMeal] = useState(defaultMeal)
     const [selectedFood, setSelectedFood] = useState(null)
     const [servingSize, setServingSize] = useState(100)
+    const [servings, setServings] = useState(1)
     const [servingUnit, setServingUnit] = useState(
         () => localStorage.getItem('preferredUnit') || 'g'
     )
@@ -67,6 +68,7 @@ export default function FoodSearch({ date, onClose, defaultMeal = 'snack' }) {
 
     const handleSelectFood = (food) => {
         setSelectedFood(food)
+        setServings(1)
         // Default to the foods actual serving size
         if (servingUnit === 'oz') {
             setServingSize(Math.round((food.servingSize / OZ_TO_G) * 10) / 10)
@@ -79,13 +81,13 @@ export default function FoodSearch({ date, onClose, defaultMeal = 'snack' }) {
 
     const handleConfirm = () => {
         if(!selectedFood) return
-        const macros = calculateMacros(selectedFood, servingSize, servingUnit)
+        const macros = calculateMacros(selectedFood, servingSize, servingUnit, servings)
 
         addFood.mutate({
             date,
             meal: selectedMeal,
             foodName: selectedFood.name,
-            servingSize,
+            servingSize: servingSize * servings,
             servingUnit,
             calories: macros.calories,
             protein: macros.protein,
@@ -95,7 +97,7 @@ export default function FoodSearch({ date, onClose, defaultMeal = 'snack' }) {
         onClose()
     }
 
-    const preview = selectedFood && servingSize > 0 ? calculateMacros(selectedFood, servingSize, servingUnit) : null
+    const preview = selectedFood && servingSize > 0 ? calculateMacros(selectedFood, servingSize, servingUnit, servings) : null
     
     const meals = ['breakfast', 'lunch', 'dinner', 'snack']
 
@@ -268,9 +270,85 @@ export default function FoodSearch({ date, onClose, defaultMeal = 'snack' }) {
                                 ))}
                             </div>
 
+                            {/* Serving input */}
+                            <div style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '8px',
+                                marginTop: '8px'
+                            }}>
+                                <span style={{
+                                    fontSize: '12px',
+                                    color: 'var(--text-muted)',
+                                    whiteSpace: 'nowrap'
+                                }}>
+                                    Servings:
+                                </span>
+                                <div style={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    border: '1px solid var(--border)',
+                                    borderRadius: 'var(--radius-sm)',
+                                    overflow: 'hidden'
+                                }}>
+                                    <button
+                                        onClick={() => setServings(prev => Math.max(0.5, Math.round((prev - 0.5) * 10) / 10))}
+                                        style={{
+                                            padding: '8px 12px',
+                                            background: 'var(--bg-secondary)',
+                                            border: 'none',
+                                            cursor: 'pointer',
+                                            color: 'var(--text-primary)',
+                                            fontSize: '16px',
+                                            fontWeight: '500'
+                                        }}
+                                    >
+                                        −
+                                    </button>
+                                    <input
+                                        type="number"
+                                        value={servings}
+                                        onChange={(e) => setServings(Math.max(0.5, Number(e.target.value)))}
+                                        onFocus={(e) => e.target.select()}
+                                        min="0.5"
+                                        step="0.5"
+                                        style={{
+                                            width: '50px',
+                                            padding: '8px 4px',
+                                            border: 'none',
+                                            background: 'var(--bg-input)',
+                                            color: 'var(--text-primary)',
+                                            fontSize: '14px',
+                                            fontWeight: '600',
+                                            textAlign: 'center'
+                                        }}
+                                    />
+                                    <button
+                                        onClick={() => setServings(prev => Math.round((prev + 0.5) * 10) / 10)}
+                                        style={{
+                                            padding: '8px 12px',
+                                            background: 'var(--bg-secondary)',
+                                            border: 'none',
+                                            cursor: 'pointer',
+                                            color: 'var(--text-primary)',
+                                            fontSize: '16px',
+                                            fontWeight: '500'
+                                        }}
+                                    >
+                                        +
+                                    </button>
+                                </div>
+                                <span style={{
+                                        fontSize: '12px',
+                                        color: 'var(--text-muted)'
+                                }}>
+                                    {servings === 1 ? '1 serving' : `${servings} servings`}
+                                </span>
+                            </div>
+
                             <span style={{
-                                fontSize: '12px',
-                                color: 'var(--text-muted)'
+                                    fontSize: '12px',
+                                    color: 'var(--text-muted)'
                             }}>
                                 serving
                             </span>

--- a/client/src/components/MealSection.jsx
+++ b/client/src/components/MealSection.jsx
@@ -28,6 +28,7 @@ export default function MealSection({ meal, entries = [], totals, date, onAddCli
   const [copyError, setCopyError] = useState(false)
   const [editingEntry, setEditingEntry] = useState(null)
   const [editValues, setEditValues] = useState({})
+  const [editServings, setEditServings] = useState(1)
 
   const isEmpty = entries.length === 0
 
@@ -53,6 +54,7 @@ export default function MealSection({ meal, entries = [], totals, date, onAddCli
 
   const handleEditStart = (entry) => {
   setEditingEntry(entry.id)
+  setEditServings(1)
   setEditValues({
     foodName:    entry.foodName,
     servingSize: entry.servingSize,
@@ -82,6 +84,19 @@ const handleEditSave = (id) => {
 const handleEditCancel = () => {
   setEditingEntry(null)
   setEditValues({})
+}
+
+const handleServingsChange = (newServings) => {
+  const ratio = newServings / editServings
+  setEditServings(newServings)
+  setEditValues(prev => ({
+    ...prev,
+    servingSize: Math.round(prev.servingSize * ratio * 10) / 10,
+    calories: Math.round(prev.calories * ratio),
+    protein: Math.round(prev.protein * ratio * 10) / 10,
+    carbs: Math.round(prev.carbs * ratio * 10) / 10,
+    fat: Math.round(prev.fat * ratio * 10) / 10,
+  }))
 }
 
   return (
@@ -317,6 +332,82 @@ const handleEditCancel = () => {
                 boxSizing: 'border-box'
               }}
             />
+
+            {/* Servings multiplier */}
+            <div style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              marginBottom: '10px'
+            }}>
+              <span style={{
+                fontSize: '12px',
+                color: 'var(--text-muted)',
+                whiteSpace: 'nowrap'
+              }}>
+                Servings:
+              </span>
+              <div style={{
+                display: 'flex',
+                alignItems: 'center',
+                border: '1px solid var(--border)',
+                borderRadius: 'var(--radius-sm)',
+                overflow: 'hidden'
+              }}>
+                <button
+                  onClick={() => handleServingsChange(Math.max(0.5, Math.round((editServings - 0.5) * 10) / 10))}
+                  style={{
+                    padding: '6px 10px',
+                    background: 'var(--bg-secondary)',
+                    border: 'none',
+                    cursor: 'pointer',
+                    color: 'var(--text-primary)',
+                    fontSize: '16px',
+                    fontWeight: '500'
+                  }}
+                >
+                  −
+                </button>
+                <input
+                  type="number"
+                  value={editServings}
+                  onChange={(e) => handleServingsChange(Math.max(0.5, Number(e.target.value)))}
+                  onFocus={(e) => e.target.select()}
+                  min="0.5"
+                  step="0.5"
+                  style={{
+                    width: '50px',
+                    padding: '6px 4px',
+                    border: 'none',
+                    background: 'var(--bg-input)',
+                    color: 'var(--text-primary)',
+                    fontSize: '13px',
+                    fontWeight: '600',
+                    textAlign: 'center'
+                  }}
+                />
+                <button
+                  onClick={() => handleServingsChange(Math.round((editServings + 0.5) * 10) / 10)}
+                  style={{
+                    padding: '6px 10px',
+                    background: 'var(--bg-secondary)',
+                    border: 'none',
+                    cursor: 'pointer',
+                    color: 'var(--text-primary)',
+                    fontSize: '16px',
+                    fontWeight: '500'
+                  }}
+                >
+                  +
+                </button>
+              </div>
+              <span style={{
+                fontSize: '12px',
+                color: 'var(--text-muted)'
+              }}>
+                {editServings === 1 ? '1 serving' : `${editServings} servings`}
+              </span>
+            </div>
 
             {/* Macro fields */}
             <div style={{

--- a/client/src/pages/CreateSavedMealPage.jsx
+++ b/client/src/pages/CreateSavedMealPage.jsx
@@ -5,10 +5,15 @@ import { searchFoods } from '../api/foods.js'
 
 const OZ_TO_G = 28.3495
 
-function calculateMacros(food, userServingSize, userServingUnit) {
-  const userGrams = userServingUnit === 'oz' ? userServingSize * OZ_TO_G : userServingSize
-  const baseGrams = food.servingSize || 100
-  const ratio = userGrams / baseGrams
+function calculateMacros(food, userServingSize, userServingUnit, servings = 1) {
+    const userGrams = userServingUnit === 'oz' ? userServingSize * OZ_TO_G : userServingSize
+
+//   const baseGrams = food.servingSize || 100
+    const baseGrams = food.servingSize === 'oz' 
+    ? (food.servingSize || 100) * OZ_TO_G
+    : (food.servingSize || 100)
+
+    const ratio = (userGrams / baseGrams) * servings
 
     return {
         calories: Math.round(food.calories * ratio),
@@ -32,6 +37,7 @@ export default function CreateSavedMealPage() {
     const [searching, setSearching] = useState(false)
     const [selectedFood, setSelectedFood] = useState(null)
     const [servingSize, setServingSize] = useState(100)
+    const [servings, setServings] = useState(1)
     const [servingUnit, setServingUnit] = useState(
         () => localStorage.getItem('preferredUnit') || 'g'
     )
@@ -64,6 +70,7 @@ export default function CreateSavedMealPage() {
 
     const handleSelectFood = (food) => {
         setSelectedFood(food)
+        setServings(1)
         // Default to the foods actual serving size
         if (servingUnit === 'oz') {
             setServingSize(Math.round((food.servingSize / OZ_TO_G) * 10) / 10)
@@ -76,14 +83,15 @@ export default function CreateSavedMealPage() {
 
     const handleAddItem = () => {
         if (!selectedFood) return 
-        const macros = calculateMacros(selectedFood, servingSize, servingUnit)
+        const macros = calculateMacros(selectedFood, servingSize, servingUnit, servings)
         setItems(prev => [...prev, {
             foodName: selectedFood.name,
-            servingSize, 
+            servingSize: servingSize * servings, 
             servingUnit,
             ...macros
         }])
         setSelectedFood(null)
+        setServings(1)
         servingSize(100)
     }
 
@@ -99,7 +107,7 @@ export default function CreateSavedMealPage() {
     }
 
     const preview = selectedFood  && servingSize > 0
-        ? calculateMacros(selectedFood, servingSize, servingUnit) : null
+        ? calculateMacros(selectedFood, servingSize, servingUnit, servings) : null
 
     const totalMacros = items.reduce((totals, item) => ({
         calories: totals.calories + item.calories,
@@ -458,10 +466,86 @@ export default function CreateSavedMealPage() {
                             : 'var(--text-secondary)'
                         }}
                         >
-                        {unit}
+                            {unit}
                         </button>
                     ))}
                     </div>
+                </div>
+                
+                {/* Servings input */}
+                <div style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '8px',
+                marginTop: '8px'
+                }}>
+                <span style={{
+                    fontSize: '12px',
+                    color: 'var(--text-muted)',
+                    whiteSpace: 'nowrap'
+                }}>
+                    Servings:
+                </span>
+                <div style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    border: '1px solid var(--border)',
+                    borderRadius: 'var(--radius-sm)',
+                    overflow: 'hidden'
+                }}>
+                    <button
+                    onClick={() => setServings(prev => Math.max(0.5, Math.round((prev - 0.5) * 10) / 10))}
+                    style={{
+                        padding: '8px 12px',
+                        background: 'var(--bg-secondary)',
+                        border: 'none',
+                        cursor: 'pointer',
+                        color: 'var(--text-primary)',
+                        fontSize: '16px',
+                        fontWeight: '500'
+                    }}
+                    >
+                    −
+                    </button>
+                    <input
+                    type="number"
+                    value={servings}
+                    onChange={(e) => setServings(Math.max(0.5, Number(e.target.value)))}
+                    onFocus={(e) => e.target.select()}
+                    min="0.5"
+                    step="0.5"
+                    style={{
+                        width: '50px',
+                        padding: '8px 4px',
+                        border: 'none',
+                        background: 'var(--bg-input)',
+                        color: 'var(--text-primary)',
+                        fontSize: '14px',
+                        fontWeight: '600',
+                        textAlign: 'center'
+                    }}
+                    />
+                    <button
+                    onClick={() => setServings(prev => Math.round((prev + 0.5) * 10) / 10)}
+                    style={{
+                        padding: '8px 12px',
+                        background: 'var(--bg-secondary)',
+                        border: 'none',
+                        cursor: 'pointer',
+                        color: 'var(--text-primary)',
+                        fontSize: '16px',
+                        fontWeight: '500'
+                    }}
+                    >
+                    +
+                    </button>
+                </div>
+                <span style={{
+                    fontSize: '12px',
+                    color: 'var(--text-muted)'
+                }}>
+                    {servings === 1 ? '1 serving' : `${servings} servings`}
+                </span>
                 </div>
 
                 {/* Serving Hints */}


### PR DESCRIPTION
## Feature: Serving Size Multiplier

### What it does
Users can now set the number of servings when logging 
food — all macros scale automatically.

### Where it works
- USDA food search — before adding to a meal
- Create saved meal — when building a template
- Edit logged food — adjust servings on already logged items
- ChompAI review — adjust AI parsed entries before confirming

### How it works
- +/- stepper with 0.5 increment (min 0.5 servings)
- Live preview updates all macros instantly
- Base values stored separately so multiplying is always 
  relative to original values not previously multiplied values

### Example
1 scrambled egg → 91 cal, 6g protein
Set servings to 2 → 182 cal, 12g protein