### PR TITLE
feat: covert logged meal to saved meal template

### DIFF
--- a/client/src/api/savedMeals.js
+++ b/client/src/api/savedMeals.js
@@ -10,6 +10,11 @@ export const createSavedMeal = async (data) => {
     return response.data
 }
 
+export const saveLoggedMealAsTemplate = async ({ date, meal, name, description }) => {
+    const response = await axiosClient.post('/api/foods/save-as-meal', {date, meal, name, description })
+    return response.data
+}
+
 export const deleteSavedMeal = async (id) => {
     const response = await axiosClient.delete(`/api/saved-meals/${id}`)
     return response.data

--- a/client/src/components/MealSection.jsx
+++ b/client/src/components/MealSection.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useDeleteFood, useCopyMeal, useUpdateFood } from '../hooks/useDailyLog.js'
+import { useSaveAsMeal } from '../hooks/useSavedMeals.js'
 
 const mealEmojis = {
   breakfast: '🌅',
@@ -21,6 +22,7 @@ export default function MealSection({ meal, entries = [], totals, date, onAddCli
   const deleteFood = useDeleteFood(date)
   const updateFood = useUpdateFood(date)
   const copyMeal = useCopyMeal(date)
+  const saveAsMeal = useSaveAsMeal()
 
   const [movingEntry, setMovingEntry] = useState(null)
   const [showCopyConfirm, setShowCopyConfirm] = useState(false)
@@ -29,6 +31,11 @@ export default function MealSection({ meal, entries = [], totals, date, onAddCli
   const [editingEntry, setEditingEntry] = useState(null)
   const [editValues, setEditValues] = useState({})
   const [editServings, setEditServings] = useState(1)
+  const [showSaveModal, setShowSaveModal] = useState(false)
+  const [saveName, setSaveName] = useState('')
+  const [saveDescription, setSaveDescription] = useState('')
+  const [saveSuccess, setSaveSuccess] = useState(false)
+  const [saveError, setSaveError] = useState(false)
 
   const isEmpty = entries.length === 0
 
@@ -97,6 +104,28 @@ const handleServingsChange = (newServings) => {
     carbs: Math.round(prev.carbs * ratio * 10) / 10,
     fat: Math.round(prev.fat * ratio * 10) / 10,
   }))
+}
+
+const handleSaveAsMeal = () => {
+  if (!saveName.trim()) return 
+  saveAsMeal.mutate({
+    date,
+    meal,
+    name: saveName,
+    description: saveDescription
+  }, {
+    onSuccess: () => {
+      setShowSaveModal(false)
+      setSaveName('')
+      setSaveDescription('')
+      setSaveSuccess(true)
+      setTimeout(() => setSaveSuccess(false), 2000)
+    },
+    onError: (() => {
+      setSaveError(true)
+      setTimeout(() => setSaveError(false), 2000)
+    })
+  })
 }
 
   return (
@@ -182,7 +211,44 @@ const handleServingsChange = (newServings) => {
             }
           </button>
         </div>
+
+        {/* Save as template button */}
+        {!isEmpty && (
+          <button
+            onClick={() => {
+              setSaveName(`My ${meal.charAt(0).toUpperCase() + meal.slice(1)}`)
+              setShowSaveModal(true)
+            }}
+            title="Save as meal template"
+            style={{
+              background: saveSuccess
+                ? 'var(--success)'
+                : saveError
+                  ? 'rgba(226,75,74,0.1)'
+                  : 'none',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius-sm)',
+              padding: '4px 8px',
+              cursor: 'pointer',
+              color: saveSuccess
+                ? 'white'
+                : saveError
+                  ? 'var(--error)'
+                  : 'var(--text-muted)',
+              fontSize: '12px',
+              transition: 'all 0.2s ease'
+            }}
+          >
+            {saveSuccess
+              ? '✓ Saved!'
+              : saveError
+                ? '✗ Failed'
+                : <>💾 <span className="icon-label">Save as Meal</span></>
+            }
+          </button>
+        )}
       </div>
+
 
       {/* Copy from yesterday confirmation */}
       {showCopyConfirm && (
@@ -227,6 +293,104 @@ const handleServingsChange = (newServings) => {
               }}
             >
               Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Save as template modal */}
+      {showSaveModal && (
+        <div style={{
+          padding: '12px 16px',
+          background: 'var(--bg-secondary)',
+          borderBottom: '1px solid var(--border)'
+        }}>
+          <div style={{
+            fontSize: '13px',
+            color: 'var(--text-primary)',
+            fontWeight: '500',
+            marginBottom: '10px'
+          }}>
+            Save {meal} as a meal template
+          </div>
+
+          <input
+            type="text"
+            value={saveName}
+            onChange={(e) => setSaveName(e.target.value)}
+            placeholder="Meal's name"
+            onFocus={(e) => e.target.select()}
+            style={{
+              width: '100%',
+              padding: '8px',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius-sm)',
+              background: 'var(--bg-input)',
+              color: 'var(--text-primary)',
+              fontSize: '13px',
+              boxSizing: 'border-box',
+              marginBottom: '8px'
+            }}
+          />
+
+          <input
+            type="text"
+            value={saveDescription}
+            onChange={(e) => setSaveDescription(e.target.value)}
+            placeholder="Description (optional)"
+            style={{
+              width: '100%',
+              padding: '8px',
+              border: '1px solid var(--border)',
+              borderRadius: 'var(--radius-sm)',
+              background: 'var(--bg-input)',
+              color: 'var(--text-primary)',
+              fontSize: '13px',
+              boxSizing: 'border-box',
+              marginBottom: '10px'
+            }}
+          />
+
+          <div style={{ display: 'flex', gap: '8px' }}>
+            <button
+              onClick={() => {
+                setShowSaveModal(false)
+                setSaveName('')
+                setSaveDescription('')
+              }}
+              style={{
+                flex: 1,
+                padding: '7px',
+                background: 'none',
+                border: '1px solid var(--border)',
+                borderRadius: 'var(--radius-sm)',
+                fontSize: '12px',
+                cursor: 'pointer',
+                color: 'var(--text-secondary)'
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSaveAsMeal}
+              disabled={!saveName.trim() || saveAsMeal.isPending}
+              style={{
+                flex: 2,
+                padding: '7px',
+                background: !saveName.trim()
+                  ? 'var(--bg-secondary)'
+                  : 'var(--accent)',
+                color: !saveName.trim()
+                  ? 'var(--text-muted)'
+                  : 'var(--accent-text)',
+                border: 'none',
+                borderRadius: 'var(--radius-sm)',
+                fontSize: '12px',
+                fontWeight: '500',
+                cursor: !saveName.trim() ? 'not-allowed' : 'pointer'
+              }}
+            >
+              {saveAsMeal.isPending ? 'Saving...' : '💾 Save template'}
             </button>
           </div>
         </div>

--- a/client/src/hooks/useSavedMeals.js
+++ b/client/src/hooks/useSavedMeals.js
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getSavedMeals, createSavedMeal, deleteSavedMeal, logSavedMeal } from '../api/savedMeals.js'
+import { getSavedMeals, createSavedMeal, saveLoggedMealAsTemplate, deleteSavedMeal, logSavedMeal } from '../api/savedMeals.js'
 
 export function useSavedMeals() {
     return useQuery({
@@ -14,6 +14,16 @@ export function useCreateSavedMeal() {
         mutationFn: createSavedMeal,
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['savedMeals']})
+        }
+    })
+}
+
+export function useSaveAsMeal() {
+    const queryClient = useQueryClient()
+    return useMutation ({
+        mutationFn: saveLoggedMealAsTemplate,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['saveMeals']})
         }
     })
 }

--- a/server/src/controllers/foods.js
+++ b/server/src/controllers/foods.js
@@ -169,3 +169,56 @@ export const copyMealFromYesterday = async (req, res) => {
         res.status(500).json({ error: 'Failed to copy Meal' })
     }
 }
+
+export const saveAsMeal = async (req, res) => {
+    try {
+        const { date, meal, name, description } = req.body
+        const userId = req.user.userId
+
+        // ***** Get all food entries for this date and meal *****
+        const entries = await prisma.foodLog.findMany({
+            where: {
+                userId, 
+                meal,
+                date: {
+                    gte: new Date(date + 'T00:00:00.000Z'),
+                    lte: new Date(date + 'T23:59:59.999Z')
+                }
+            }
+        })
+
+        if (entries.length === 0) {
+            return res.status(404).json({ error: `No ${meal} entries found for this date` })
+        }
+
+        // ***** Create saved meal with those items *****
+        const savedMeal = await prisma.savedMeal.create({
+            data: {
+                userId,
+                name,
+                description: description || '',
+                items: {
+                    create: entries.map(entry => ({
+                        foodName: entry.foodName,
+                        servingSize: entry.servingSize,
+                        servingUnit: entry.servingUnit,
+                        calories: entry.calories,
+                        protein: entry.protein,
+                        carbs: entry.carbs,
+                        fat: entry.fat
+                    }))
+                }
+            },
+            include: { items: true }
+        })
+
+        res.status(201).json({
+            message: `${meal} saved as a meal template`,
+            savedMeal: JSON.parse(JSON.stringify(savedMeal))
+        })
+
+    } catch (err) {
+        console.error(err)
+        res.status(500).json({ error: 'Failed to save meal template' })
+    }
+}

--- a/server/src/routes/foods.js
+++ b/server/src/routes/foods.js
@@ -1,14 +1,15 @@
 import { Router } from 'express' 
-import { getFoodLog, addFoodLog, deleteFoodEntry, updateFoodEntry, copyMealFromYesterday } from '../controllers/foods.js' 
+import { getFoodLog, addFoodLog, deleteFoodEntry, updateFoodEntry, copyMealFromYesterday, saveAsMeal } from '../controllers/foods.js' 
 import { authenticateToken } from '../middleware/auth.js'
 import { validate } from '../middleware/validate.js'
-import { foodEntrySchema, updateFoodSchema, copyMealSchema } from '../validators/foods.js'
+import { foodEntrySchema, updateFoodSchema, copyMealSchema, saveAsMealSchema } from '../validators/foods.js'
 
 const router = Router() 
 
 router.get('/:date', authenticateToken, getFoodLog)
 router.post('/', authenticateToken, validate(foodEntrySchema), addFoodLog) 
 router.post('/copy', authenticateToken, validate(copyMealSchema), copyMealFromYesterday)
+router.post('/save-as-meal', authenticateToken, validate(saveAsMealSchema), saveAsMeal)
 router.delete('/:id', authenticateToken, deleteFoodEntry)
 router.patch('/:id', authenticateToken, validate(updateFoodSchema), updateFoodEntry)
 

--- a/server/src/validators/foods.js
+++ b/server/src/validators/foods.js
@@ -35,3 +35,10 @@ export const copyMealSchema = z.object({
     date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD format'),
     meal: z.enum(['breakfast', 'lunch', 'dinner', 'snack'])
 })
+
+export const saveAsMealSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be YYYY-MM-DD format'),
+  meal: z.enum(['breakfast', 'lunch', 'dinner', 'snack']),
+  name: z.string().min(1, 'Meal name is required').max(100),
+  description: z.string().max(200).optional()
+})


### PR DESCRIPTION
## Feature: Convert Logged Meal to Saved Meal Template

### What it does
Users can save any logged meal section directly as a 
reusable saved meal template from the dashboard.

### Use case
User logs their usual breakfast, realizes they eat it 
every day, and wants to save it as a template instead 
of searching for each food again tomorrow.

### Backend
- New POST /api/foods/save-as-meal endpoint
- Fetches all FoodLog entries for given date + meal
- Creates SavedMeal with all items in one transaction
- Returns 404 if no entries found for that meal

### Frontend
- 💾 Save as template button on each meal section header
  (only shows when meal has food logged)
- Inline modal with pre-filled meal name
  e.g. "My Breakfast", "My Lunch"
- Optional description field
- Same inline success/error feedback pattern as Copy button
  ✓ Saved! on success, ✗ Failed on error
- New template instantly available in Saved Meals page

### Validators
- New saveAsMealSchema added to foods validators
- date, meal, name (required), description (optional)